### PR TITLE
Adds htmlmin; builds index file.

### DIFF
--- a/app/pages/index.hbs
+++ b/app/pages/index.hbs
@@ -1,7 +1,11 @@
 <h1>INDEX PAGE</h1>
 <ul>
-  {{#each results}}
-    <li>{{data.name}}</li>
+  {{#each index.results}}
+    <li>
+      <a href="/events/{{ id }}">
+        {{ name }}
+      </a>
+    </li>
   {{/each}}
 </ul>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -23,11 +23,24 @@ module.exports = function(grunt) {
         flatten: true,
         layout: ['app/templates/layout.hbs'],
         partials: ['app/partials/*.hbs'],
-        data: 'data/past.json'
+        data: 'data/*.json'
       },
       build: {
         src: 'app/pages/*.hbs',
         dest: 'tmp/'
+      }
+    },
+
+    htmlmin: {
+      options: {
+        removeComments: true,
+        collapseWhitespace: true
+      },
+      build: {
+        expand: true,
+        cwd: 'tmp',
+        src: ['*.html'],
+        dest: 'output'
       }
     }
   });
@@ -36,6 +49,7 @@ module.exports = function(grunt) {
     'clean',
     'copy',
     'assemble',
+    'htmlmin'
   ]);
 
   grunt.registerTask('default', 'An alias of build.', ['build']);

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "devDependencies": {
     "assemble": "^0.4.42",
     "grunt": "^0.4.5",
-    "load-grunt-tasks": "^0.6.0",
     "grunt-contrib-copy": "^0.6.0",
-    "grunt-contrib-clean": "^0.6.0"
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-htmlmin": "^0.3.0",
+    "load-grunt-tasks": "^0.6.0"
   }
 }


### PR DESCRIPTION
More work on tha build system
- Actually uses data to build the index page
- Minifies HTML
- Compiles files to the public directory
# 
##### To test
- Copy the contents of [this gist](https://gist.github.com/jmeas/cec06ad14502f9e593bf) into a file `data/index.json`
- Run `grunt` from the command line
- Start a simple server (such as [node-static](https://github.com/cloudhead/node-static#command-line-interface)) from the public directory
  `npm install -g node-static && cd public && static`
- Navigate to `http://127.0.0.1:8080/`

It should work! :birthday: 
